### PR TITLE
Replaced lodash.isarray with Array.isArray

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "hex-to-hsl": "^1.0.2",
     "hsl-to-hex": "^1.0.0",
     "lodash.flow": "^3.3.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isfunction": "^3.0.8"
   },
   "devDependencies": {

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -1,5 +1,4 @@
 
-import isArray from 'lodash.isarray';
 import _hslToHex from 'hsl-to-hex';
 import hexToHsl from 'hex-to-hsl';
 
@@ -24,7 +23,7 @@ export const colorToHSL = c => {
 
 // Returns an hex string value, whatever color type is passed in argument
 export const colorToHex = c => {
-	if (isArray(c)) {
+	if (Array.isArray(c)) {
 		return _hslToHex(...c);
 	}
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,12 +1,10 @@
 
-import isArray from 'lodash.isarray';
-
 // Change an hsl object { hue: int, sat: int, lit: int } to an array [int, int, int]
 export const hslObjToArray = ({hue, sat, lit}) => [hue, sat, lit];
 
 // Returns a boolean telling if this is a valid hsl array [int, int, int]
 export const isHSLArray = c =>
-	isArray(c) && c.length === 3 &&
+	Array.isArray(c) && c.length === 3 &&
 	typeof c[0] === 'number' && c[0] >= 0 && c[0] <= 360 &&
 	typeof c[1] === 'number' && c[1] >= 0 && c[1] <= 100 &&
 	typeof c[2] === 'number' && c[2] >= 0 && c[2] <= 100;


### PR DESCRIPTION
lodash.isarray is deprecated. Array.isArray should be used instead.